### PR TITLE
Bump PyTorch Lite to 1.12.0

### DIFF
--- a/PLMLibTorchWrapper.podspec
+++ b/PLMLibTorchWrapper.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
 
     spec.source_files = "ios/LibTorchWrapper/LibTorchWrapper/**/*.{h,m,mm}"
 
-    spec.dependency 'LibTorch-Lite', '1.11.0'
+    spec.dependency 'LibTorch-Lite', '1.12.0'
 
     spec.xcconfig = {
         'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/LibTorch-Lite/install/include/"',

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,7 +68,7 @@ kotlin {
         val androidMain by getting {
             dependencies {
                 rootProject
-                implementation("org.pytorch:pytorch_android_lite:1.11")
+                implementation("org.pytorch:pytorch_android_lite:1.12.1")
             }
         }
         val androidTest by getting {

--- a/ios/LibTorchWrapper/PLMLibTorchWrapper.podspec
+++ b/ios/LibTorchWrapper/PLMLibTorchWrapper.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |spec|
 
     spec.source_files = "LibTorchWrapper/**/*.{h,m,mm}"
 
-    spec.dependency 'LibTorch-Lite', '1.11.0'
+    spec.dependency 'LibTorch-Lite', '1.12.0'
 
     spec.xcconfig = {
         'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/LibTorch-Lite/install/include/"',

--- a/ios/LibTorchWrapper/Podfile
+++ b/ios/LibTorchWrapper/Podfile
@@ -6,6 +6,6 @@ target 'LibTorchWrapper' do
   use_frameworks!
 
   # Pods for LibTorchWrapper
-  pod 'LibTorch-Lite', '1.11.0'
+  pod 'LibTorch-Lite', '1.12.0'
   
 end

--- a/ios/LibTorchWrapper/Podfile.lock
+++ b/ios/LibTorchWrapper/Podfile.lock
@@ -1,20 +1,20 @@
 PODS:
-  - LibTorch-Lite (1.11.0):
-    - LibTorch-Lite/Core (= 1.11.0)
-  - LibTorch-Lite/Core (1.11.0):
+  - LibTorch-Lite (1.12.0):
+    - LibTorch-Lite/Core (= 1.12.0)
+  - LibTorch-Lite/Core (1.12.0):
     - LibTorch-Lite/Torch
-  - LibTorch-Lite/Torch (1.11.0)
+  - LibTorch-Lite/Torch (1.12.0)
 
 DEPENDENCIES:
-  - LibTorch-Lite (= 1.11.0)
+  - LibTorch-Lite (= 1.12.0)
 
 SPEC REPOS:
   trunk:
     - LibTorch-Lite
 
 SPEC CHECKSUMS:
-  LibTorch-Lite: 14eb78f01cb0c9b5caaaf98c05c3faa1810cbca5
+  LibTorch-Lite: c2210be0ed41c3a7f972c82715663a44d35ad97c
 
-PODFILE CHECKSUM: d1b9333c0845db3ce9b7b9b5b8255db0b64e787f
+PODFILE CHECKSUM: bc7247ebc31742154602ce637c65c9becdce3435
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
* [x] [wait for CocoaPods release](https://github.com/CocoaPods/Specs/tree/master/Specs/c/c/3/LibTorch-Lite)
* [x] fix checksums in `Podfile.lock` (by building via XCode?)
* [x] rebase & fix commits